### PR TITLE
Support Larger Files with Asset Data Type

### DIFF
--- a/Sources/Model/Dotfiles/Sync+add().swift
+++ b/Sources/Model/Dotfiles/Sync+add().swift
@@ -68,9 +68,12 @@ extension Sync {
 
         return DispatchQueue.global().async(.promise) {
             let record = CKRecord(recordType: .recordType, recordID: CKRecord.ID(recordName: relativePath))
-            let data = try Data(contentsOf: validatedUrl)
-            record[.data] = data as CKRecordValue
-            record[.checksum] = data.md5 as CKRecordValue
+            
+            let checksum = try Data(contentsOf: validatedUrl).md5
+            let asset = CKAsset(fileURL: validatedUrl)
+
+            record[.asset] = asset
+            record[.checksum] = checksum as CKRecordValue
             return record
         }.then {
             save($0)

--- a/Sources/Model/Dotfiles/etc.swift
+++ b/Sources/Model/Dotfiles/etc.swift
@@ -7,6 +7,6 @@ var db: CKDatabase {
 
 extension String {
     static let recordType = "dotfile"
-    static let data = "data"
+    static let asset = "asset"
     static let checksum = "md5"
 }


### PR DESCRIPTION
I put this PR together to show how this would work, and did a quick test to make sure it worked. This pull request changes the data type from Bytes to Asset, and creates a new `CKAsset` when uploading.

Note: This does not convert existing records, so I changed the field name from `data` to `asset` to keep compatibility.