### PR TITLE
Fix NSOpenPanel sometimes become missing

### DIFF
--- a/Sources/AppDelegate+add().swift
+++ b/Sources/AppDelegate+add().swift
@@ -38,7 +38,6 @@ extension AppDelegate {
     }
 
     @objc private func showAddFilesPanel(sender: Any) {
-        guard let window = rootViewController?.view.window else { return }
 
         func add(_ urls: [URL]) {
             addButton.isEnabled = false
@@ -61,7 +60,7 @@ extension AppDelegate {
         panel.directoryURL = Path.home.url
         panel.treatsFilePackagesAsDirectories = true
         panel.isExtensionHidden = false
-        panel.beginSheetModal(for: window) { rsp in
+        panel.begin { rsp in
             if rsp == .OK {
                 add(panel.urls)
             }


### PR DESCRIPTION
## Problem

Open panel sometimes become invisible by steps below.

- select "Add file"
- select other app (this makes Workbench and its open panel to be hidden)
- select "Add file" again but **nothing happens**

I guess it's AppKit's bug?

Mohave 10.14.5 Beta (18F96h)

## Resolution

Open the panel in new window, instead of as a sheet panel.